### PR TITLE
Handle show and close for window

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <LangVersion>preview</LangVersion>
     <NoWarn>CS1591;CS0649;CS8632;CA1416</NoWarn>
-    <Version>1.0.1</Version>
+    <Version>1.1.0</Version>
     <AssemblyVersion>1.0.0</AssemblyVersion>
     <PackageTags>Avalonia, Verify</PackageTags>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/StandaloneExampleTest.XUnit/Tests.cs
+++ b/src/StandaloneExampleTest.XUnit/Tests.cs
@@ -13,14 +13,7 @@ public class Tests
             Content = testSubject,
             SizeToContent = SizeToContent.WidthAndHeight,
         };
-        try
-        {
-            window.Show();
-            return Verify(window);
-        }
-        finally
-        {
-            window.Close();
-        }
+
+        return Verify(window);
     }
 }

--- a/src/Verify.Avalonia/VerifyAvalonia.cs
+++ b/src/Verify.Avalonia/VerifyAvalonia.cs
@@ -14,8 +14,22 @@ public static partial class VerifyAvalonia
         Initialized = true;
 
         InnerVerifier.ThrowIfVerifyHasBeenRun();
+        VerifierSettings.RegisterFileConverter<Window>(WindowToImage);
         VerifierSettings.RegisterFileConverter<TopLevel>(TopLevelToImage);
         AddConverters();
+    }
+
+    static ConversionResult WindowToImage(Window window, IReadOnlyDictionary<string, object> context)
+    {
+        window.Show();
+        return new(
+            window,
+            [new("png", window.ToImage())],
+            () =>
+            {
+                window.Close();
+                return Task.CompletedTask;
+            });
     }
 
     static ConversionResult TopLevelToImage(TopLevel topLevel, IReadOnlyDictionary<string, object> context) =>

--- a/src/XUnitTests/Tests.cs
+++ b/src/XUnitTests/Tests.cs
@@ -5,8 +5,6 @@ public class Tests
     {
         var window = new RecursiveWindow();
 
-        window.Show();
-
         return Verify(window);
     }
 }


### PR DESCRIPTION
remove the need for show and close when verifying a window

before 
```
[AvaloniaFact]
public Task Test()
{
    var testSubject = new Button
    {
        Content = "Click me!"
    };

    var window = new Window
    {
        Content = testSubject,
        SizeToContent = SizeToContent.WidthAndHeight,
    };
    try
    {
        window.Show();
        return Verify(window);
    }
    finally
    {
        window.Close();
    }
}
```

after

```
[AvaloniaFact]
public Task Test()
{
    var testSubject = new Button
    {
        Content = "Click me!"
    };

    var window = new Window
    {
        Content = testSubject,
        SizeToContent = SizeToContent.WidthAndHeight,
    };

    return Verify(window);
}
```