### PR TITLE
Fix UI-thread window cleanup and PNG save

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <LangVersion>preview</LangVersion>
     <NoWarn>CS1591;CS0649;CS8632;CA1416;NU1608;NU1109</NoWarn>
-    <Version>1.4.0</Version>
+    <Version>1.4.1</Version>
     <AssemblyVersion>1.0.0</AssemblyVersion>
     <PackageTags>Avalonia, Verify</PackageTags>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -3,32 +3,32 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Avalonia" Version="12.0.5" />
-    <PackageVersion Include="Avalonia.Controls.ColorPicker" Version="12.0.5" />
-    <PackageVersion Include="Avalonia.Controls.DataGrid" Version="12.0.1" />
-    <PackageVersion Include="Avalonia.Desktop" Version="12.0.5" />
+    <PackageVersion Include="Avalonia" Version="12.1.0" />
+    <PackageVersion Include="Avalonia.Controls.ColorPicker" Version="12.1.0" />
+    <PackageVersion Include="Avalonia.Controls.DataGrid" Version="12.1.0" />
+    <PackageVersion Include="Avalonia.Desktop" Version="12.1.0" />
     <PackageVersion Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.3" />
-    <PackageVersion Include="Avalonia.Fonts.Inter" Version="12.0.5" />
-    <PackageVersion Include="Avalonia.Headless" Version="12.0.5" />
-    <PackageVersion Include="Avalonia.Headless.NUnit" Version="12.0.5" />
-    <PackageVersion Include="Avalonia.Headless.XUnit" Version="12.0.5" />
-    <PackageVersion Include="Avalonia.Skia" Version="12.0.5" />
-    <PackageVersion Include="Avalonia.Themes.Fluent" Version="12.0.5" />
+    <PackageVersion Include="Avalonia.Fonts.Inter" Version="12.1.0" />
+    <PackageVersion Include="Avalonia.Headless" Version="12.1.0" />
+    <PackageVersion Include="Avalonia.Headless.NUnit" Version="12.1.0" />
+    <PackageVersion Include="Avalonia.Headless.XUnit" Version="12.1.0" />
+    <PackageVersion Include="Avalonia.Skia" Version="12.1.0" />
+    <PackageVersion Include="Avalonia.Themes.Fluent" Version="12.1.0" />
     <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.4.2" />
     <PackageVersion Include="MarkdownSnippets.MsBuild" Version="28.4.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageVersion Include="NUnit" Version="4.6.1" />
     <PackageVersion Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageVersion Include="ProjectDefaults" Version="1.0.174" />
-    <PackageVersion Include="Verify" Version="31.22.0" />
+    <PackageVersion Include="Verify" Version="31.24.0" />
     <PackageVersion Include="Verify.CommunityToolkit.Mvvm" Version="1.1.0" />
     <PackageVersion Include="Verify.DiffPlex" Version="3.3.0" />
-    <PackageVersion Include="Verify.NUnit" Version="31.22.0" />
-    <PackageVersion Include="Verify.XunitV3" Version="31.22.0" />
+    <PackageVersion Include="Verify.NUnit" Version="31.24.0" />
+    <PackageVersion Include="Verify.XunitV3" Version="31.24.0" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="Microsoft.Sbom.Targets" Version="4.1.5" />
     <PackageVersion Include="Argon" Version="0.35.0" />
-    <PackageVersion Include="DiffEngine" Version="19.3.1" />
+    <PackageVersion Include="DiffEngine" Version="19.3.2" />
     <PackageVersion Include="EmptyFiles" Version="8.18.2" />
     <PackageVersion Include="SimpleInfoName" Version="3.2.0" />
   </ItemGroup>

--- a/src/Verify.Avalonia/Extensions.cs
+++ b/src/Verify.Avalonia/Extensions.cs
@@ -9,7 +9,7 @@
         }
 
         var stream = new MemoryStream();
-        bitmap.Save(stream);
+        bitmap.Save(stream, PngBitmapEncoderOptions.Default);
         return stream;
     }
 }

--- a/src/Verify.Avalonia/GlobalUsings.cs
+++ b/src/Verify.Avalonia/GlobalUsings.cs
@@ -7,3 +7,4 @@ global using Avalonia.Diagnostics;
 global using Avalonia.Headless;
 global using Avalonia.Input;
 global using Avalonia.Media;
+global using Avalonia.Media.Imaging;

--- a/src/Verify.Avalonia/VerifyAvalonia.cs
+++ b/src/Verify.Avalonia/VerifyAvalonia.cs
@@ -1,6 +1,7 @@
 ﻿using System.ComponentModel;
 using System.Windows.Input;
 using Avalonia.Styling;
+using Avalonia.Threading;
 
 namespace VerifyTests;
 
@@ -54,11 +55,10 @@ public static partial class VerifyAvalonia
 
 
     static Func<Task> Cleanup(Window window) =>
-        () =>
-        {
-            window.Close();
-            return Task.CompletedTask;
-        };
+        // Marshal the close onto the UI thread: Verify's awaits use ConfigureAwait(false),
+        // so the cleanup callback can run off the Avalonia UI thread, and Window.Close now
+        // touches thread-affine state (IsVisible) that throws when accessed cross-thread.
+        () => Dispatcher.UIThread.InvokeAsync(window.Close).GetTask();
 
     static ConversionResult WindowToImage(Window window, IReadOnlyDictionary<string, object> context)
     {


### PR DESCRIPTION
Update bitmap serialization to explicitly use `PngBitmapEncoderOptions.Default` when saving to a stream. Also change window cleanup to close via `Dispatcher.UIThread.InvokeAsync(...)` so Verify cleanup runs safely on the Avalonia UI thread, avoiding cross-thread exceptions introduced by thread-affine `Window.Close` behavior.